### PR TITLE
Fix docs and config out of sync with new features

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -16,6 +16,12 @@
       "source": "./plugins/product-writing-studio",
       "description": "Expert product communicator — exec updates, strategy memos, board decks, stakeholder emails, product announcements, one-pagers, design briefs, and launch comms. Audience-first, pyramid-principle driven, anti-jargon.",
       "version": "1.1.0"
+    },
+    {
+      "name": "pm-interview-prep",
+      "source": "./plugins/pm-interview-prep",
+      "description": "PM interview coach — product sense, execution, estimation, and behavioral question coaching with JTBD-framed answers, structured decomposition, STAR format, mock interview mode, and anti-pattern detection.",
+      "version": "1.0.0"
     }
   ]
 }

--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -11,6 +11,11 @@ on:
         description: "Claude model"
         required: false
         default: "claude-opus-4-6"
+      baseline:
+        description: "Run baseline comparison (skill vs vanilla Claude)"
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   eval:
@@ -27,4 +32,6 @@ jobs:
         run: |
           PLUGIN_ARG=""
           if [ -n "${{ inputs.plugin }}" ]; then PLUGIN_ARG="--plugin ${{ inputs.plugin }}"; fi
-          python scripts/run_evals.py $PLUGIN_ARG --model "${{ inputs.model }}"
+          BASELINE_ARG=""
+          if [ "${{ inputs.baseline }}" = "true" ]; then BASELINE_ARG="--baseline"; fi
+          python scripts/run_evals.py $PLUGIN_ARG --model "${{ inputs.model }}" $BASELINE_ARG

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,45 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+## [1.4.0] - 2026-03-15
+
+### Added — PM Interview Prep Plugin
+- New plugin: PM Interview Prep — senior PM interview coach for Claude
+- 321-line SKILL.md covering product sense (JTBD-framed), execution, estimation (structured decomposition), and behavioral (STAR format) question coaching
+- Mock interview mode: Claude plays interviewer, asks follow-ups, then scores on 4-dimension rubric
+- Anti-pattern detection for 6 common interview answer failures (too broad, no metrics, no tradeoffs, solution-first, no user empathy, rambling)
+- Company-type calibration for FAANG, growth-stage, enterprise, and consumer interviews
+- `evals/pm-interview-prep/cases.json` — 6 behavioral eval cases
+- `plugins/pm-interview-prep/README.md` — plugin deep-dive and install guide
+- Added to `marketplace.json` and `.claude-plugin/marketplace.json`
+
+### Added — Teardown Enhancements
+- `--vs` comparison mode: head-to-head product analysis across 6 dimensions + 7th "Head-to-Head Verdict" (e.g., `python scripts/teardown.py "Notion" --vs "Coda"`)
+- `--output social` format: thread-ready summary with hook, 5 bullet verdicts, and bottom line
+- Async parallel API calls via `asyncio` + `anthropic.AsyncAnthropic` — ~4x faster teardowns
+- 4 example teardowns in `examples/teardowns/`: Notion, Linear, Figma, ChatGPT
+
+### Added — Eval Enhancements
+- `--baseline` flag for `run_evals.py`: runs each case with and without the skill, shows per-case and overall behavioral lift scores
+- 5 new strategic-pm eval cases (spm-008 through spm-012): Why Now pressure test, second-order consequence identification, Decision Journal generation, PM Maturity Adapter detection, GTM launch tiering
+- 5 new product-writing-studio eval cases (pws-008 through pws-012): passive voice detection, board deck narrative structure, stakeholder email format, one-pager length enforcement, wall-of-text anti-pattern
+- Total eval coverage: 30 cases across 3 plugins (was 14 across 2)
+
+### Added — Community Loop
+- GitHub Action: teardown-on-issue (`teardown.yml`) — label an issue `teardown`, get results as a comment
+- Issue template: `teardown_request.md` for zero-barrier teardown requests
+- 5/day rate limit to manage API costs
+
+### Changed — README
+- New "Example Teardowns" section with links to 4 product teardowns
+- PM Interview Prep listed as ✅ Live in Available Plugins and Marketplace Roadmap
+- Teardown Tool section updated with `--vs`, `--output social` docs
+- Eval Harness section updated with `--baseline` mode docs
+- New "Teardown-on-Issue" section
+- Repo structure diagram updated
+- Eval badge updated to 30 cases
+- Version badge updated to 1.4.0
+
 ## [1.3.0] - 2026-03-08
 
 ### Added — AI Product Teardown Tool

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,7 +116,7 @@ Check the [Marketplace Roadmap](README.md#marketplace-roadmap) in the README. Yo
 
 These are starting points, not prescriptions. Surprise us.
 
-- **UX Strategy** — heuristics evaluation, cognitive load analysis, interaction pattern selection, accessibility audits, design system constraints
+- **UX Strategy** — heuristics evaluation, cognitive load analysis, interaction pattern selection, accessibility audits, design system constraints (next planned plugin)
 - **Research Ops** — interview guide generation, synthesis protocols, survey design, participant screening criteria
 - **Engineering Collaboration** — technical spec reviews, architecture decision records, API design principles, tech debt prioritization
 - **Data & Experimentation** — experiment design rigor, statistical significance checks, metric definition standards, dashboard critique
@@ -163,7 +163,10 @@ description: >
 ---
 ```
 
-After the frontmatter, write the skill instructions in Markdown. Refer to the Strategic PM plugin (`plugins/strategic-pm/skills/strategic-pm/SKILL.md`) as an example of structure and style.
+After the frontmatter, write the skill instructions in Markdown. Refer to the existing plugins as examples of structure and style:
+- `plugins/strategic-pm/skills/strategic-pm/SKILL.md` — comprehensive PM co-pilot (469 lines)
+- `plugins/product-writing-studio/skills/product-writing-studio/SKILL.md` — focused writing coach (307 lines)
+- `plugins/pm-interview-prep/skills/pm-interview-prep/SKILL.md` — interview coaching with mock mode (321 lines)
 
 #### Quality bar for new plugins
 

--- a/README.md
+++ b/README.md
@@ -266,10 +266,7 @@ productkit/
 ├── .github/
 │   ├── workflows/teardown.yml             # Teardown-on-issue Action
 │   └── ISSUE_TEMPLATE/teardown_request.md
-├── teardowns/                             # Saved teardown reports (gitignored)
-└── releases/
-    ├── strategic-pm-v1.0.0.zip
-    └── product-writing-studio-v1.1.0.zip
+└── teardowns/                             # Saved teardown reports (gitignored)
 ```
 
 ---

--- a/evals/README.md
+++ b/evals/README.md
@@ -59,6 +59,7 @@ python scripts/run_evals.py
 ```bash
 python scripts/run_evals.py --plugin strategic-pm
 python scripts/run_evals.py --plugin product-writing-studio
+python scripts/run_evals.py --plugin pm-interview-prep
 ```
 
 **Options:**
@@ -67,6 +68,22 @@ python scripts/run_evals.py --output json          # JSON output instead of term
 python scripts/run_evals.py --model claude-haiku-4-5-20251001  # Cheaper model for iteration
 python scripts/run_evals.py --plugin strategic-pm --output json
 ```
+
+**Baseline mode (skill vs vanilla Claude):**
+```bash
+python scripts/run_evals.py --plugin strategic-pm --baseline
+```
+
+Baseline mode runs every eval case twice — once with the skill as system prompt, once with an empty system prompt (vanilla Claude). It shows per-case and overall behavioral lift:
+
+```
+spm-001 · Reverse Brief trigger on PRD request
+  WITH skill:    10/10 (100%) ✅
+  WITHOUT skill:  3/10 (30%)  ❌
+  Skill lift: +70 points
+```
+
+This is the most powerful proof that a skill changes behavior. If vanilla Claude scores similarly, the skill isn't doing enough.
 
 ---
 
@@ -170,7 +187,7 @@ A failing case means the skill's behavioral claim is not reliably being honored 
 
 ## Cost
 
-Each eval case makes 2 API calls (subject + grader). At Opus pricing (~$15/M input, $75/M output), a full 14-case run costs approximately **$1–2**.
+Each eval case makes 2 API calls (subject + grader). At Opus pricing (~$15/M input, $75/M output), a full 30-case run costs approximately **$2–4**.
 
 This is why the workflow is `workflow_dispatch` only — not triggered on every push or PR.
 


### PR DESCRIPTION
1. Add pm-interview-prep to .claude-plugin/marketplace.json
2. Add [1.4.0] entry to CHANGELOG.md with all new features
3. Add --baseline docs and update case count in evals/README.md
4. Reference pm-interview-prep in CONTRIBUTING.md plugin examples
5. Add --baseline checkbox to eval.yml workflow_dispatch inputs
6. Remove non-existent releases/ dir from README repo structure

# Pull Request

## Summary

What does this PR change, and why?

## Type of change

- [ ] Improving an existing plugin (new framework, edge case, anti-pattern, fix)
- [ ] New plugin
- [ ] Documentation fix
- [ ] Infrastructure / tooling

---

## Checklist

### All PRs
- [ ] `CHANGELOG.md` updated under `## [Unreleased]`
- [ ] No broken links in any modified `.md` files

### Plugin changes (new or updated)
- [ ] `plugin.json` updated (version bumped if this is a content change)
- [ ] `SKILL.md` instructions are in imperative form ("Do X", not "You should X")
- [ ] Each new framework includes: when to apply it, what it produces, an example
- [ ] Anti-patterns covered for any new framework
- [ ] Confidence labels (`🟢 High / 🟡 Medium / 🔴 Low`) used where appropriate

### New plugins only
- [ ] `.claude-plugin/plugin.json` created with correct `name`, `version`, `description`, `skills`
- [ ] `SKILL.md` file exists at the path referenced in `plugin.json`
- [ ] Example conversations included (before/after the skill is installed)
- [ ] Plugin listed in root `marketplace.json`

### Test conversations
Paste 1–2 example prompts and Claude's response with this skill active. This is the quality bar — if you can't show it working well, it's not ready.

**Prompt 1:**
> [your test prompt]

**Response:**
> [Claude's actual output]

---

## Breaking changes

Does this change alter existing behavior? If yes, describe what changes and why it's worth the disruption.
